### PR TITLE
Components: add a ClippedImage component

### DIFF
--- a/modules/LuneOS/Components/ClippedImage.qml
+++ b/modules/LuneOS/Components/ClippedImage.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.0
+
+Item {
+    id: clippingItem
+
+    // url of the original image
+    property alias source: clippedImage.source
+    // size of the original image
+    property size imageSize
+    // size of the grid (number of horizontal patches, number of vertical patches)
+    property size patchGridSize
+    // current patch coordinates. Numbering begins at 0.
+    property point patch
+    // constrain the width of the resulting patch image.
+    // If zero, the patch image will be scaled w.r.t. the original image proportions and wantedHeight
+    property real wantedWidth: 0
+    // constrain the height of the resulting patch image.
+    // If zero, the patch image will be scaled w.r.t. the original image proportions and wantedWidth
+    property real wantedHeight: 0
+
+    width: wantedWidth
+    height: wantedHeight
+
+    Binding {
+        target: clippingItem
+        property: "width"
+        when: wantedWidth <= 0
+        value: height * (imageSize.width/imageSize.height) / patchGridSize.width
+    }
+    Binding {
+        target: clippingItem
+        property: "height"
+        when: wantedHeight <= 0
+        value: width * (imageSize.height/imageSize.width) / patchGridSize.height
+    }
+
+    QtObject {
+        id: internal
+        property size patchSize: Qt.size(imageSize.width/patchGridSize.width, imageSize.height/patchGridSize.height);
+        property real scalingX: clippingItem.width / patchSize.width;
+        property real scalingY: clippingItem.height / patchSize.height;
+    }
+
+    clip: true
+
+    Image {
+        id: clippedImage
+
+        width: clippingItem.imageSize.width * internal.scalingX
+        height: clippingItem.imageSize.height * internal.scalingY
+
+        x: -1 * patch.x * internal.patchSize.width * internal.scalingX
+        y: -1 * patch.y * internal.patchSize.height * internal.scalingY
+
+        horizontalAlignment: Image.AlignLeft
+        verticalAlignment: Image.AlignTop
+        fillMode: Image.Stretch
+    }
+}

--- a/modules/LuneOS/Components/qmldir
+++ b/modules/LuneOS/Components/qmldir
@@ -5,6 +5,7 @@ Page 1.0 Page.qml
 AlertDialog 1.0 AlertDialog.qml
 AuthenticationDialog 1.0 AuthenticationDialog.qml
 CertDialog 1.0 CertDialog.qml
+ClippedImage 1.0 ClippedImage.qml
 ConfirmDialog 1.0 ConfirmDialog.qml
 ContextMenuExtras.qml 1.0 ContextMenuExtras.qml
 DialogButton 1.0 DialogButton.qml


### PR DESCRIPTION
This component helps manipulating images composed of a grid of image patches.
It is possible to stretch and scale the resulting patch.

For example, this kind of image: https://github.com/webOS-ports/org.webosports.app.phone/blob/master/qml/views/images/dial-button.png contains a grid of patches of size (1,3).

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>