### PR TITLE
Change PhoneNumber to PhoneNumberLib

### DIFF
--- a/modules/LuneOS/Telephony/libphonenumber-wrapper.js
+++ b/modules/LuneOS/Telephony/libphonenumber-wrapper.js
@@ -33,14 +33,14 @@ Qt.include("phonenumber.js/PhoneNumber.js");
 
 function normalizePhoneNumber(phoneNumber, countryCode)
 {
-    var phoneNumberObj = PhoneNumber.Parse(phoneNumber, countryCode);
+    var phoneNumberObj = PhoneNumberLib.Parse(phoneNumber, countryCode);
 
     // try to be compatible with Enyo g11n
     if (phoneNumberObj) {
         // reverse of "+-countrycode--national_number_without_leading_digits-extension"
         var phoneNatNumberWithoutLeadingDigits = phoneNumberObj.nationalNumber.substr(phoneNumberObj.leadingDigit.length);
 
-        var normalizedNumber = "+-"+phoneNumberObj.regionMetaData.countryCode + "--" + phoneNatNumberWithoutLeadingDigits + "-";
+        var normalizedNumber = "+-"+phoneNumberObj.regionMetaData.countryCode + "-" + phoneNumberObj.leadingDigit + "-" + phoneNatNumberWithoutLeadingDigits + "-";
         var reversedNormalizedNumber = normalizedNumber.split("").reverse().join("");
 
         console.log("normalizePhoneNumber("+phoneNumber+")="+reversedNormalizedNumber);

--- a/modules/LuneOS/Telephony/phonenumber.js/PhoneNumber.js
+++ b/modules/LuneOS/Telephony/phonenumber.js/PhoneNumber.js
@@ -1,7 +1,7 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-var PhoneNumber = (function (dataBase) {
+var PhoneNumberLib = (function (dataBase) {
   // Use strict in our context only - users might not want it
   'use strict';
 


### PR DESCRIPTION
This avoids future namespace conflicts with the Enyo g11n PhoneNumber class.

Also change the normalized format to always include the leading digits.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>