### PR TITLE
lunaserviceadapter: include appid in the service calls

### DIFF
--- a/modules/LuneOS/Service/plugin/lunaserviceadapter.cpp
+++ b/modules/LuneOS/Service/plugin/lunaserviceadapter.cpp
@@ -129,7 +129,8 @@ bool LunaServiceCall::execute(const QString& uri, const QString& arguments)
     QString errorMessage;
 
     if (mResponseLimit == 1) {
-        if (!LSCallOneReply(mServiceHandle, uri.toUtf8().constData(), arguments.toUtf8().constData(),
+        if (!LSCallFromApplicationOneReply(mServiceHandle, uri.toUtf8().constData(), arguments.toUtf8().constData(),
+                            LSHandleGetName(mServiceHandle),
                             &LunaServiceCall::responseCallback, this, &mToken, &error)) {
             qWarning("Failed to call remote service %s", uri.toUtf8().constData());
             errorMessage = QString("Failed to call remote service: %0").arg(error.message);
@@ -137,7 +138,8 @@ bool LunaServiceCall::execute(const QString& uri, const QString& arguments)
         }
     }
     else {
-        if (!LSCall(mServiceHandle, uri.toUtf8().constData(), arguments.toUtf8().constData(),
+        if (!LSCallFromApplication(mServiceHandle, uri.toUtf8().constData(), arguments.toUtf8().constData(),
+                            LSHandleGetName(mServiceHandle),
                             &LunaServiceCall::responseCallback, this, &mToken, &error)) {
             qWarning("Failed to call remote service %s", uri.toUtf8().constData());
             errorMessage = QString("Failed to call remote service: %0").arg(error.message);
@@ -359,6 +361,16 @@ void LunaServiceAdapter::setResponseCallback(QJSValue callback)
 void LunaServiceAdapter::setErrorCallback(QJSValue callback)
 {
     mErrorCallback = callback;
+}
+
+QJSValue LunaServiceAdapter::getResponseCallback() const
+{
+    return mResponseCallback;
+}
+
+QJSValue LunaServiceAdapter::getErrorCallback() const
+{
+    return mErrorCallback;
 }
 
 void LunaServiceAdapter::updateCallUri()

--- a/modules/LuneOS/Service/plugin/lunaserviceadapter.h
+++ b/modules/LuneOS/Service/plugin/lunaserviceadapter.h
@@ -82,8 +82,8 @@ class LunaServiceAdapter : public QObject,
     Q_PROPERTY(bool usePrivateBus READ usePrivateBus WRITE setUsePrivateBus)
     Q_PROPERTY(QString service READ service WRITE setService)
     Q_PROPERTY(QString method READ method WRITE setMethod)
-    Q_PROPERTY(QJSValue onResponse WRITE setResponseCallback)
-    Q_PROPERTY(QJSValue onError WRITE setErrorCallback)
+    Q_PROPERTY(QJSValue onResponse READ getResponseCallback WRITE setResponseCallback)
+    Q_PROPERTY(QJSValue onError READ getErrorCallback WRITE setErrorCallback)
 
 public:
     LunaServiceAdapter(QObject *parent = 0);
@@ -96,6 +96,8 @@ public:
     bool usePrivateBus() const;
     QString service() const;
     QString method() const;
+    QJSValue getResponseCallback() const;
+    QJSValue getErrorCallback() const;
 
     void setName(const QString& name);
     void setUsePrivateBus(bool usePrivateBus);


### PR DESCRIPTION
Also fix a Qt warning about missing WRITE methods.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>