### PR TITLE
UserAgent.qml: Make sure all urls are lowercase before we start to do…

### DIFF
--- a/modules/LuneOS/Components/UserAgent.qml
+++ b/modules/LuneOS/Components/UserAgent.qml
@@ -52,7 +52,7 @@ Item {
     property var overrides: Overrides.overrides
 
     function getDomain(url) {
-        var domain = url.toString()
+        var domain = url.toString().toLowerCase()
         var indexOfScheme = domain.indexOf("://")
         if (indexOfScheme !== -1) {
             domain = domain.slice(indexOfScheme + 3)


### PR DESCRIPTION
… anything

Since the matches are case sensitive. We can control what's in the ua-overrides.js file, but not what the user enters.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>