### PR TITLE
LunaWebEngineView: fullScreenSupportEnabled is already true by default

### DIFF
--- a/modules/LuneOS/Components/LunaWebEngineView.qml
+++ b/modules/LuneOS/Components/LunaWebEngineView.qml
@@ -17,8 +17,8 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-import QtQuick 2.6
-import QtWebEngine 1.4
+import QtQuick 2.9
+import QtWebEngine 1.6
 import Qt.labs.settings 1.0
 
 WebEngineView {
@@ -53,7 +53,6 @@ WebEngineView {
     settings.javascriptCanAccessClipboard: true
     settings.localContentCanAccessRemoteUrls: true
     settings.pluginsEnabled: true
-    settings.fullScreenSupportEnabled: true
     
     profile.httpUserAgent: userAgent.defaultUA
 


### PR DESCRIPTION
In addition, it seems there is a bug in QML properties versioning,
as we are now encountering a blocking error in LunaWebAppManager:

"Apr 20 05:32:20 tissot LunaWebAppManager[2799]: WARNING: 05:32:20.636:
file:///usr/lib/qml/LuneOS/Components/LunaWebEngineView.qml:56:14:
".fullScreenSupportEnabled" is not available due to component versioning."

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>