### PR TITLE
LunaService stub: update the getPreferences URI

### DIFF
--- a/test/imports/LuneOS/Service/LunaService.qml
+++ b/test/imports/LuneOS/Service/LunaService.qml
@@ -185,7 +185,10 @@ QtObject {
             console.log("bootmgr status: normal");
             returnFct({"payload": JSON.stringify({"subscribed":true, "state": "normal"})}); // simulate subscription answer
         }
-        else if((serviceURI === "palm://com.palm.systemservice/getPreferences" || serviceURI === "luna://com.palm.systemservice/getPreferences") && args.subscribe) {
+        else if((serviceURI === "palm://com.palm.systemservice/getPreferences" ||
+                 serviceURI === "luna://com.palm.systemservice/getPreferences" ||
+                 serviceURI === "luna://com.webos.service.systemservice/getPreferences" )
+                && args.subscribe) {
             returnFct({"payload": JSON.stringify({"subscribed": true, "wallpaper": { "wallpaperFile": "images/background.jpg"}, "timeFormat":"HH24", "locale": { "languageCode": "en", "countryCode": "us", "phoneRegion": { "countryName": "United States", "countryCode": "us" } }})});
         }
         else if(serviceURI === "luna://org.webosports.audio/getStatus") {


### PR DESCRIPTION
LunaNext now uses luna://com.webos.service.systemservice/getPreferences.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>