### PR TITLE
luneos-components: Fix implicit declaration of QML Connections

### DIFF
--- a/modules/LuneOS/Bluetooth/BluetoothManager.qml
+++ b/modules/LuneOS/Bluetooth/BluetoothManager.qml
@@ -110,7 +110,7 @@ Item {
     /* Bindings to keep the discovering mode updated */
     Connections {
         target: btManager
-        onUsableAdapterChanged: {
+        function onUsableAdapterChanged() {
             if(btManager.usableAdapter && root.discoveringMode)
                 btManager.usableAdapter.startDiscovery();
         }

--- a/modules/LuneOS/Components/CertDialog.qml
+++ b/modules/LuneOS/Components/CertDialog.qml
@@ -48,7 +48,9 @@ Dialog {
 
         Connections {
             target: certDialog
-            onViewCertificate: notImplemented.visible = true;
+            function onViewCertificate() {
+                notImplemented.visible = true;
+            }
         }
     }
 

--- a/test/imports/LunaNext/Compositor/Singletons/WindowModelSingleton.qml
+++ b/test/imports/LunaNext/Compositor/Singletons/WindowModelSingleton.qml
@@ -39,7 +39,7 @@ Item {
     Connections {
         target: _compositor
 
-        onWindowAddedInListModel: {
+        function onWindowAddedInListModel(window) {
             if( window.windowType === 0 )
                 windowModelSingleton.appendValue(cardListModel, {"window": window});
             else if( window.windowType === 1 )
@@ -55,7 +55,7 @@ Item {
             else if( window.windowType === 6 )
                 windowModelSingleton.appendValue(pinListModel, {"window": window});
         }
-        onWindowRemovedFromListModel: {
+        function onWindowRemovedFromListModel(window) {
             if( window.windowType === 0 )
                 windowModelSingleton.removeValue(cardListModel,window);
             else if( window.windowType === 1 )


### PR DESCRIPTION
To solve the following types of warnings:

QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>