### PR TITLE
LuneOSBlueToothAgent: capability should be variant

### DIFF
--- a/test/imports/LuneOS/Bluetooth/LuneOSBluetoothAgent.qml
+++ b/test/imports/LuneOS/Bluetooth/LuneOSBluetoothAgent.qml
@@ -20,7 +20,7 @@ import QtQuick 2.0
 QtObject {
     id: agentId
     property string path: "/"
-    property int capability;
+    property variant capability;
 
     function registerToManager(btManager) {
         console.log("==> registerToManager()");


### PR DESCRIPTION
According to https://github.com/mer-packages/mcts-blts/blob/29cbfb0a104343cd436a632c8dbe76d1cd6905ef/mcts-mwts/generic/mwts-bluetooth/src/bluetoothdbus.cpp#L186 capability should be variant and not int.

I got the following error:
org.webosports.app.settings/src/qml/Connectivity/BluetoothPage.qml:40:9: Unable to assign [undefined] to int

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>