### PR TITLE
UserAgent.qml: Make Qt and Chrome version flexible

### DIFF
--- a/modules/LuneOS/Components/UserAgent.qml
+++ b/modules/LuneOS/Components/UserAgent.qml
@@ -36,7 +36,7 @@ Item {
     // %1: form factor (Mobile, Tablet, Desktop)
     // %2: WebKit version
     //readonly property string _template: "Mozilla/5.0 (LuneOS; %1) WebKit/%2"
-    readonly property string _template: "Mozilla/5.0 (LuneOS, like webOS/3.5.0; %1) AppleWebKit/%2 (KHTML, like Gecko) QtWebEngine/5.15.0 Chrome/80.0.3987.163 Safari/%2"
+    readonly property string _template: "Mozilla/5.0 (LuneOS, like webOS/3.5.0; %1) AppleWebKit/%2 (KHTML, like Gecko) QtWebEngine/@QT_VERSION@ Chrome/@CHROMIUM_VERSION@ Safari/%2"
 
     // See Source/WebCore/Configurations/Version.xcconfig in QtWebKit’s source tree
     // TODO: determine this value at runtime


### PR DESCRIPTION
Automatically Qt and Chrome versions during build, so we don't need to manually do it, since we tend to forget to do it every once in a while.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>